### PR TITLE
docs: Spell fox32 in lowercase

### DIFF
--- a/docs/cpu.md
+++ b/docs/cpu.md
@@ -1,6 +1,6 @@
-# Fox32 CPU
+# fox32 CPU
 
-This document aims to describe the CPU in the the Fox32 architecture.
+This document aims to describe the CPU in the the fox32 architecture.
 Peripherals such as the disk controller are described elsewhere.
 
 
@@ -11,7 +11,7 @@ All 16-bit or 32-bit values are stored in memory in little-endian order.
 
 ## Registers
 
-The Fox32 CPU has the following registers:
+The fox32 CPU has the following registers:
 
 - **r0-r31**: 32-bit general-purpose registers
 - **rsp**: current stack pointer
@@ -31,7 +31,7 @@ The Fox32 CPU has the following registers:
 
 ## External buses
 
-There are two kinds of external bus that the Fox32 CPU can address:
+There are two kinds of external bus that the fox32 CPU can address:
 
 - **Memory**: Data is read from and written to memory with the `mov` instruction,
   instructions are fetch from memory.

--- a/docs/instructions.md
+++ b/docs/instructions.md
@@ -1,7 +1,7 @@
 # Fox32 instructions
 
-This file describes every Fox32 instruction in detail. For a general
-description of the Fox32 CPU, see cpu.md.
+This file describes every fox32 instruction in detail. For a general
+description of the fox32 CPU, see cpu.md.
 
 ## NOP: no operation
 ## ADD: add


### PR DESCRIPTION
As requested by @ry755: https://github.com/fox32-arch/fox32/pull/2#issuecomment-1368289018