### PR TITLE
Headless Mode

### DIFF
--- a/src/cpu.h
+++ b/src/cpu.h
@@ -58,6 +58,7 @@ typedef struct {
     bool halted;
 
     bool debug;
+    bool headless;
 
     bool mmu_enabled;
 

--- a/src/main.c
+++ b/src/main.c
@@ -58,6 +58,7 @@ int main(int argc, char *argv[]) {
                     "  --disk DISK    Specify a disk image to use\n"
                     "  --rom ROM      Specify a ROM image to use\n"
                     "  --debug        Enable debug output\n"
+                    "  --headless     Headless mode: don't open a window\n"
                    , argv[0]);
             return 0;
         } else if (strcmp(argv[i], "--disk") == 0) {
@@ -78,31 +79,36 @@ int main(int argc, char *argv[]) {
             }
         } else if (strcmp(argv[i], "--debug") == 0) {
             vm.debug = true;
+        } else if (strcmp(argv[i], "--headless") == 0) {
+            vm.headless = true;
         } else {
             fprintf(stderr, "unrecognized option %s\n", argv[i]);
             return 1;
         }
     }
-    if (SDL_Init(SDL_INIT_VIDEO) != 0) {
-        fprintf(stderr, "unable to initialize SDL: %s", SDL_GetError());
-        return 1;
+
+    if (!vm.headless) {
+        if (SDL_Init(SDL_INIT_VIDEO) != 0) {
+            fprintf(stderr, "unable to initialize SDL: %s", SDL_GetError());
+            return 1;
+        }
+
+        SDL_ShowCursor(SDL_DISABLE);
+
+        ScreenCreate(
+            FRAMEBUFFER_WIDTH, FRAMEBUFFER_HEIGHT,
+            draw_framebuffer,
+            key_pressed,
+            key_released,
+            mouse_pressed,
+            mouse_released,
+            mouse_moved,
+            drop_file
+        );
+
+        ScreenInit();
+        ScreenDraw();
     }
-
-    SDL_ShowCursor(SDL_DISABLE);
-
-    ScreenCreate(
-        FRAMEBUFFER_WIDTH, FRAMEBUFFER_HEIGHT,
-        draw_framebuffer,
-        key_pressed,
-        key_released,
-        mouse_pressed,
-        mouse_released,
-        mouse_moved,
-        drop_file
-    );
-
-    ScreenInit();
-    ScreenDraw();
 
     tick_start = SDL_GetTicks();
     tick_end = SDL_GetTicks();
@@ -158,7 +164,8 @@ void main_loop(void) {
     }
 
     if ((ticks % TPF) == 0) {
-        ScreenDraw();
+        if (!vm.headless)
+            ScreenDraw();
         fox32_raise(&vm, VSYNC_INTERRUPT_VECTOR);
         vm.halted = false;
     }

--- a/src/main.c
+++ b/src/main.c
@@ -40,13 +40,6 @@ void main_loop(void);
 void load_rom(const char *filename);
 
 int main(int argc, char *argv[]) {
-    if (SDL_Init(SDL_INIT_VIDEO) != 0) {
-        fprintf(stderr, "unable to initialize SDL: %s", SDL_GetError());
-        return 1;
-    }
-
-    SDL_ShowCursor(SDL_DISABLE);
-
     fox32_init(&vm);
     vm.io_read = bus_io_read;
     vm.io_write = bus_io_write;
@@ -90,6 +83,12 @@ int main(int argc, char *argv[]) {
             return 1;
         }
     }
+    if (SDL_Init(SDL_INIT_VIDEO) != 0) {
+        fprintf(stderr, "unable to initialize SDL: %s", SDL_GetError());
+        return 1;
+    }
+
+    SDL_ShowCursor(SDL_DISABLE);
 
     ScreenCreate(
         FRAMEBUFFER_WIDTH, FRAMEBUFFER_HEIGHT,


### PR DESCRIPTION
This PR adds a --headless option to fox32.

When I tested locally, I found that fox32 still starts without complaint when I unset `$DISPLAY` (because SDL has a video driver that thinks it can work under these conditions), but the same isn't true in CI.

The changes are best viewed commit by commit and with the "hide whitespace" option enabled.