### PR TITLE
GitHub CI: Bump actions/checkout to v3

### DIFF
--- a/.github/workflows/fox32-unstable-linux.yml
+++ b/.github/workflows/fox32-unstable-linux.yml
@@ -11,7 +11,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Download latest fox32rom artifact
         uses: dawidd6/action-download-artifact@v2


### PR DESCRIPTION
v2 is deprecated and causes a warning on the Actions page.