### PR TITLE
Added scale filtering for high DPI monitors

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -54,17 +54,21 @@ int main(int argc, char *argv[]) {
     memcpy(vm.memory_rom, fox32rom, sizeof(fox32rom));
 
     size_t disk_id = 0;
+    int filtering_mode = 0;
 #ifndef __EMSCRIPTEN__
     for (int i = 1; i < argc; i++) {
         if (strcmp(argv[i], "--help") == 0) {
             fprintf(stderr,
                     "Usage: %s [OPTIONS]\n\n"
                     "Options:\n"
-                    "  --help         Print this message\n"
-                    "  --disk DISK    Specify a disk image to use\n"
-                    "  --rom ROM      Specify a ROM image to use\n"
-                    "  --debug        Enable debug output\n"
-                    "  --headless     Headless mode: don't open a window\n"
+                    "  --help             Print this message\n"
+                    "  --disk DISK        Specify a disk image to use\n"
+                    "  --rom ROM          Specify a ROM image to use\n"
+                    "  --debug            Enable debug output\n"
+                    "  --headless         Headless mode: don't open a window\n"
+                    "  --filtering MODE   Set scale filtering mode for high DPI displays\n"
+                    "                       0 = nearest pixel (default)\n"
+                    "                       1 = linear filtering\n"
                    , argv[0]);
             return 0;
         } else if (strcmp(argv[i], "--disk") == 0) {
@@ -87,6 +91,21 @@ int main(int argc, char *argv[]) {
             vm.debug = true;
         } else if (strcmp(argv[i], "--headless") == 0) {
             vm.headless = true;
+        } else if (strcmp(argv[i], "--filtering") == 0) {
+            if (i + 1 < argc) {
+                if (strcmp(argv[i + 1], "0") == 0) {
+                    filtering_mode = 0; // nearest pixel filtering
+                } else if (strcmp(argv[i + 1], "1") == 0) {
+                    filtering_mode = 1; // linear filtering
+                } else {
+                    fprintf(stderr, "incorrect scale filtering mode specified\n");
+                    return 1;
+                }
+                i++;
+            } else {
+                fprintf(stderr, "no scale filtering mode specified\n");
+                return 1;
+            }
         } else {
             fprintf(stderr, "unrecognized option %s\n", argv[i]);
             return 1;
@@ -106,6 +125,7 @@ int main(int argc, char *argv[]) {
 
         ScreenCreate(
             FRAMEBUFFER_WIDTH, FRAMEBUFFER_HEIGHT,
+            filtering_mode,
             draw_framebuffer,
             key_pressed,
             key_released,

--- a/src/screen.c
+++ b/src/screen.c
@@ -29,13 +29,21 @@ void ScreenInit() {
         SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED,
         (int)(WindowWidth * SCREEN_ZOOM),
         (int)(WindowHeight * SCREEN_ZOOM),
-        SDL_WINDOW_HIDDEN
+        SDL_WINDOW_HIDDEN | SDL_WINDOW_ALLOW_HIGHDPI
     );
 
     if (!ScreenWindow) {
         fprintf(stderr, "failed to create window\n");
         exit(1);
     }
+
+    SDL_SetHint(SDL_HINT_WINDOWS_DPI_AWARENESS, "permonitor");
+    SDL_SetHint(SDL_HINT_WINDOWS_DPI_SCALING, "1");
+
+    // set scale filtering mode
+    char filtering[2];
+    sprintf(filtering, "%d", MainScreen.ScaleFiltering);
+    SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, filtering); // 0: point, 1 = linear
 
     ScreenRenderer = SDL_CreateRenderer(ScreenWindow, -1, 0);
 
@@ -164,6 +172,7 @@ struct SDL_Texture *ScreenGetTexture(struct Screen *screen) {
 
 void ScreenCreate(
     int w, int h,
+    int filtering,
     ScreenDrawF draw,
     ScreenKeyPressedF keypressed,
     ScreenKeyReleasedF keyreleased,
@@ -181,7 +190,7 @@ void ScreenCreate(
 
     MainScreen.Width = w;
     MainScreen.Height = h;
-
+    MainScreen.ScaleFiltering = filtering;
     MainScreen.Draw = draw;
     MainScreen.KeyPressed = keypressed;
     MainScreen.KeyReleased = keyreleased;

--- a/src/screen.h
+++ b/src/screen.h
@@ -15,8 +15,8 @@ typedef void (*ScreenDropFileF)(char *filename);
 struct Screen {
     int Width;
     int Height;
+    int ScaleFiltering;
     SDL_Texture *Texture;
-
     ScreenDrawF Draw;
     ScreenKeyPressedF KeyPressed;
     ScreenKeyReleasedF KeyReleased;
@@ -36,6 +36,7 @@ struct SDL_Texture *ScreenGetTexture(struct Screen *screen);
 
 void ScreenCreate(
     int w, int h,
+    int filtering,
     ScreenDrawF draw,
     ScreenKeyPressedF keypressed,
     ScreenKeyReleasedF keyreleased,


### PR DESCRIPTION
This adds scale filtering for high DPI monitors.
By default, it will set the filtering mode to point filtering (aka. nearest neighbor) for crisp pixels. The user can also choose to specify the filtering mode with the newly added `--filtering` option.

Currently, two filtering modes are available
 - 0 = point filtering (default)
 - 1 = linear filtering

This has been tested working on a MacBook Air M1. I haven't been able to test this on any other systems such as Windows, so some further testing might be necessary.