### PR TITLE
Audio controller for fox32

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,8 @@ CFILES = src/main.c \
 		src/mmu.c \
 		src/mouse.c \
 		src/screen.c \
-		src/serial.c
+		src/serial.c \
+		src/sound.c
 
 OBJS = $(addsuffix .o, $(basename $(CFILES)))
 

--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,7 @@ ifeq ($(TARGET),mingw)
 CC = x86_64-w64-mingw32-gcc
 SDL2_CONFIG = /usr/local/x86_64-w64-mingw32/bin/sdl2-config
 CFLAGS += -g -Ofast -std=c99 -Wall -Wextra -DWINDOWS -I/usr/local/x86_64-w64-mingw32/include -Dmain=SDL_main
-LDFLAGS += -lmingw32 -lSDL2main -lSDL2 -L/usr/local/x86_64-w64-mingw32/lib -lmingw32 -lSDL2main -lSDL2
-# -mwindows
+LDFLAGS += -lmingw32 -lSDL2main -lSDL2 -L/usr/local/x86_64-w64-mingw32/lib -lmingw32 -lSDL2main -lSDL2 -mwindows
 TARGET_FILE_EXTENSION = .exe
 else
 ifeq ($(TARGET),wasm)

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,8 @@ ifeq ($(TARGET),mingw)
 CC = x86_64-w64-mingw32-gcc
 SDL2_CONFIG = /usr/local/x86_64-w64-mingw32/bin/sdl2-config
 CFLAGS += -g -Ofast -std=c99 -Wall -Wextra -DWINDOWS -I/usr/local/x86_64-w64-mingw32/include -Dmain=SDL_main
-LDFLAGS += -lmingw32 -lSDL2main -lSDL2 -L/usr/local/x86_64-w64-mingw32/lib -lmingw32 -lSDL2main -lSDL2 -mwindows
+LDFLAGS += -lmingw32 -lSDL2main -lSDL2 -L/usr/local/x86_64-w64-mingw32/lib -lmingw32 -lSDL2main -lSDL2
+# -mwindows
 TARGET_FILE_EXTENSION = .exe
 else
 ifeq ($(TARGET),wasm)

--- a/docs/audio.md
+++ b/docs/audio.md
@@ -1,0 +1,129 @@
+# Audio controller
+
+The audio controller manages 8 PCM audio channels and sums them together
+to get the final audio output. The controller has a maximum output rate
+of 48kHz and can handle 8-bit/16-bit PCM samples at any physical address in memory.
+
+## Port mapping
+
+Audio ports can be accessed from the range 0x80000600-0x800006FF.
+
+All of the channel registers for the 8 channels are accessed at $00-$7F. The upper
+nibble determines the channel number, while the lower number determines the register.
+
+The range from $82-$FF is unused and reserved for future expansions.
+
+Each channel has 3 volume controls: the channel volume, the left volume and the right volume.
+The channel is scaled by the channel volume (0-127), then it is scaled according to the left
+and right volumes (both 0-255).
+
+ offset (X = 0...7) | description
+--------------------|------------------
+  0xX0              | audio channel X sample start
+  0xX1              | audio channel X sample end
+  0xX2              | audio channel X loop point start
+  0xX3              | audio channel X loop point end
+  0xX4              | audio channel X rate
+  0xX5              | audio channel X control
+  0xX6              | audio channel X panning
+  0x80              | audio controller sample base
+  0x81              | audio controller state
+
+### 0xX0: Sample position (Read)
+Read this register to get the current position of the sample that is playing in the audio channel.
+
+### 0xX1: Sample data (Read)
+Read this register to get the current output sample of the audio channel (16-bit half).
+
+### 0xX0, 0xX1: Sample start and end (Write)
+Write a number to these registers to specify the start and end of the sample relative to
+the controller's sample base.
+
+### 0xX2, 0xX3: Loop point start and end (Write-only)
+Write a number to these registers to specify the start and end of the sample relative to
+the controller's sample base. Reading these registers will return a 0.
+
+### 0xX4: Channel accumulator (Read)
+Read this register to get the current value of the channel phase accumulator.
+
+### 0xX4: Channel rate (Write)
+Write a number here to specify the rate at which samples are fetched.
+The theoretical range is from 0 to 4294967295 (2^32 - 1), however the recommended maximum is
+65536, since higher rates may result in undefined behaviour.
+
+A desired rate R can be calculated according to the formula: $\frac{R}{48000}\times2^{16}$.
+To play a sample at a sample rate of 48kHz, calculate the rate: $\frac{48000}{48000}\times2^{16} = 65536$ 
+and write the resulting rate of 65536 to this register.
+
+### 0xX5: Audio channel control (Read, Write)
+
+ bits   | description
+--------|------------------
+  31:10 | not used
+  9     | 0=8-bit PCM, 1=16-bit PCM
+  8     | enable
+  7     | loop
+  6:0   | volume (0-127)
+
+Note that the audio controller, when using 16-bit PCM, fetches 16-bit data as a little-endian word.
+
+### 0xX6: Audio panning control (Read, Write)
+
+ bits   | description
+--------|------------------
+  15:8  | left volume (0-255)
+  7:0   | right volume (0-255)
+
+### 0x80: Audio controller sample base (Read, Write)
+Read from this register to get the current base from which samples are fetched and write to it to set
+the base.
+
+### 0x81: Audio controller status (Read, Write)
+
+ bits   | description
+--------|------------------
+  15:8  | buffer rate
+  5:4   | buffer format
+  1     | refill pending flag
+  0     | buffer mode (0=use channels, 1=use buffer)
+
+Bits 15 to 8 specify the rate at which samples from the buffer are fetched. The formula for calculating
+the rate for a sample rate R is $\frac{R}{48000}\times2^{7}$. A value of 0 halts the internal counter and
+no samples are fetched until the rate is non-zero.
+  value    | description
+-----------|--------------------
+  128      | maximum rate (48kHz)
+  64       | half rate (24kHz)
+  32       | quarter rate (12khz)
+  0        | stops playback
+  \>128    | undefined behaviour
+
+If bit 0 of this port is set, then the channels are disabled and the controller now expects
+a contiguous area of 32 kilobytes (32768 bytes) for the audio buffer. This allows for
+software-driven mixing and more control over the audio output.
+The format of this buffer is determined by bits 4 and 5:
+  value    | description
+-----------|--------------------
+  0b00 (0) | mono 8-bit
+  0b01 (1) | mono 16-bit
+  0b10 (2) | stereo 8-bit
+  0b11 (3) | stereo 16-bit
+
+Stereo samples are fetched as frames of left and right. For example, if the buffer is using stereo 8-bit PCM,
+it fetches the left sample first (1 byte), then the right sample last (1 byte), advancing the internal position by 2 bytes.
+For stereo 16-bit PCM, it fetches the left sample word first (2 bytes) and the right sample word last (2 bytes),
+advancing the internal position by 4 bytes.
+
+The audio controller will always use a 32768 byte buffer, regardless of the format.
+The effective buffer size then is variable depending on the format:
+  format        | size (bytes) | buffer size (samples)
+----------------|--------------|---------------------------
+  mono 8-bit    | 1            | 32768
+  mono 16-bit   | 2            | 16384
+  stereo 8-bit  | 2            | 16384
+  stereo 16-bit | 4            | 8192
+
+Whenever the internal position is half-way through the buffer, it raises an interrupt of vector 0xFE (address 0x000003F8).
+When this interrupt is raised, the refill pending flag (bit 1) is set, and must be cleared
+in order for future refill interrupts to happen. In that case, a value of 0 must be written
+to clear the flag.

--- a/docs/audio.md
+++ b/docs/audio.md
@@ -1,21 +1,18 @@
 # Audio controller
 
-The audio controller manages 8 PCM audio channels and sums them together
-to get the final audio output. The controller has a maximum output rate
-of 48kHz and can handle 8-bit/16-bit PCM samples at any physical address in memory.
+The audio controller manages 8 PCM audio channels, summing them together
+to produce the final audio output. The controller has a maximum output rate
+of 48 kHz and can handle 8-bit or 16-bit PCM samples from any physical address in memory.
+
+Each channel has 3 volume controls: the channel volume, the left volume, and the right volume.
+The channel is scaled by the channel volume (0-127), and then by the left and right volumes (both 0-255).
 
 ## Port mapping
 
-Audio ports can be accessed from the range 0x80000600-0x800006FF.
+Audio ports can be accessed within the range 0x80000600-0x800006FF.
 
-All of the channel registers for the 8 channels are accessed at $00-$7F. The upper
-nibble determines the channel number, while the lower number determines the register.
-
-The range from $82-$FF is unused and reserved for future expansions.
-
-Each channel has 3 volume controls: the channel volume, the left volume and the right volume.
-The channel is scaled by the channel volume (0-127), then it is scaled according to the left
-and right volumes (both 0-255).
+Registers for the 8 audio channels are accessed at 0x00-0x7F. The upper nibble determines 
+the channel number, while the lower nibble determines the register.
 
  offset (X = 0...7) | description
 --------------------|------------------
@@ -26,33 +23,48 @@ and right volumes (both 0-255).
   0xX4              | audio channel X rate
   0xX5              | audio channel X control
   0xX6              | audio channel X panning
-  0x80              | audio controller sample base
-  0x81              | audio controller state
+
+Registers relating to the current status of the audio controller are located at ports 0x80 and 0x81.
+ offset | description
+--------|------------------
+  0x80  | audio controller sample base
+  0x81  | audio controller state
+
+The range from 0x82-0xFF is unused and reserved for future expansions.
 
 ### 0xX0: Sample position (Read)
-Read this register to get the current position of the sample that is playing in the audio channel.
+Read this register to get the current position of the sample being played in the audio channel.
 
 ### 0xX1: Sample data (Read)
-Read this register to get the current output sample of the audio channel (16-bit half).
+Read this register to get the current 16-bit output sample of the audio channel.
 
 ### 0xX0, 0xX1: Sample start and end (Write)
-Write a number to these registers to specify the start and end of the sample relative to
-the controller's sample base.
+Write a value to these registers to specify the start and end points of the sample relative to
+the controller's sample base. The sample endpoint written here must be the endpoint + 1.
+For example, if the sample is 8000 bytes long, then the start point should be 0 and the end point
+should be 8000. This also applies to the loop points.
+
+Note that these values are in bytes, and do not change depending on the format. If the start of
+the sample is 0 and the end of the sample is 2, then the controller will always read 2 bytes, 
+regardless of the bit-depth of the channel. This is valid for 8-bit PCM, but for a 16-bit sample
+of the same length, the endpoint value must be 4.
 
 ### 0xX2, 0xX3: Loop point start and end (Write-only)
-Write a number to these registers to specify the start and end of the sample relative to
+Write a value to these registers to specify the start and end of the sample relative to
 the controller's sample base. Reading these registers will return a 0.
 
 ### 0xX4: Channel accumulator (Read)
-Read this register to get the current value of the channel phase accumulator.
+Read this register to get the current value of the channel's phase accumulator.
 
 ### 0xX4: Channel rate (Write)
-Write a number here to specify the rate at which samples are fetched.
-The theoretical range is from 0 to 4294967295 (2^32 - 1), however the recommended maximum is
-65536, since higher rates may result in undefined behaviour.
+Write a value here to specify the rate at which samples are fetched.
+Although any 32-bit value can be written here, giving a theoretical range of 0 to 4294967295 (2^32 - 1),
+any values above 65536 will not change the frequency, and will max out at 48 kHz. The effective sampling
+rate range is from 0 hz to 48 kHz.
 
-A desired rate R can be calculated according to the formula: $\frac{R}{48000}\times2^{16}$.
-To play a sample at a sample rate of 48kHz, calculate the rate: $\frac{48000}{48000}\times2^{16} = 65536$ 
+A given frequency (F) can be calculated using the formula: $\frac{F}{48000}\times2^{16}$.
+To play a sample at a sample rate of 48 kHz, calculate the rate as follows:
+$\frac{48000}{48000}\times2^{16} = 65536$ 
 and write the resulting rate of 65536 to this register.
 
 ### 0xX5: Audio channel control (Read, Write)
@@ -65,7 +77,7 @@ and write the resulting rate of 65536 to this register.
   7     | loop
   6:0   | volume (0-127)
 
-Note that the audio controller, when using 16-bit PCM, fetches 16-bit data as a little-endian word.
+When using 16-bit PCM, the audio controller fetches 16-bit data as a little-endian word.
 
 ### 0xX6: Audio panning control (Read, Write)
 
@@ -75,8 +87,8 @@ Note that the audio controller, when using 16-bit PCM, fetches 16-bit data as a 
   7:0   | right volume (0-255)
 
 ### 0x80: Audio controller sample base (Read, Write)
-Read from this register to get the current base from which samples are fetched and write to it to set
-the base.
+Read from this register to get the current base address from which samples are fetched and
+write to it to set the base.
 
 ### 0x81: Audio controller status (Read, Write)
 
@@ -84,23 +96,23 @@ the base.
 --------|------------------
   15:8  | buffer rate
   5:4   | buffer format
-  1     | refill pending flag
+  1     | refill pending flag (read-only)
   0     | buffer mode (0=use channels, 1=use buffer)
 
-Bits 15 to 8 specify the rate at which samples from the buffer are fetched. The formula for calculating
-the rate for a sample rate R is $\frac{R}{48000}\times2^{7}$. A value of 0 halts the internal counter and
-no samples are fetched until the rate is non-zero.
+Bits 15 to 8 specify the rate at which samples are fetched from the buffer. The formula for calculating
+the rate for a given sample rate (F) is $\frac{F}{48000}\times2^{7}$. A value of 0 halts the internal counter and
+no samples are fetched until a non-zero rate is set.
   value    | description
 -----------|--------------------
-  128      | maximum rate (48kHz)
-  64       | half rate (24kHz)
-  32       | quarter rate (12khz)
+  128      | maximum rate (48 kHz)
+  64       | half rate (24 kHz)
+  32       | quarter rate (12 kHz)
   0        | stops playback
   \>128    | undefined behaviour
 
-If bit 0 of this port is set, then the channels are disabled and the controller now expects
-a contiguous area of 32 kilobytes (32768 bytes) for the audio buffer. This allows for
-software-driven mixing and more control over the audio output.
+If bit 0 of this port is set, the channels are disabled and the controller expects
+a contiguous area of 32 kilobytes (32,768 bytes) for the audio buffer. This allows for
+software-driven mixing and provides more control over the audio output.
 The format of this buffer is determined by bits 4 and 5:
   value    | description
 -----------|--------------------
@@ -109,13 +121,13 @@ The format of this buffer is determined by bits 4 and 5:
   0b10 (2) | stereo 8-bit
   0b11 (3) | stereo 16-bit
 
-Stereo samples are fetched as frames of left and right. For example, if the buffer is using stereo 8-bit PCM,
+Stereo samples are fetched as frames containing left and right samples. For example, if the buffer is using stereo 8-bit PCM,
 it fetches the left sample first (1 byte), then the right sample last (1 byte), advancing the internal position by 2 bytes.
 For stereo 16-bit PCM, it fetches the left sample word first (2 bytes) and the right sample word last (2 bytes),
 advancing the internal position by 4 bytes.
 
-The audio controller will always use a 32768 byte buffer, regardless of the format.
-The effective buffer size then is variable depending on the format:
+The audio controller always uses a 32768 byte buffer, regardless of the format.
+Consequently, the effective buffer size is variable depending on the format:
   format        | size (bytes) | buffer size (samples)
 ----------------|--------------|---------------------------
   mono 8-bit    | 1            | 32768
@@ -124,6 +136,5 @@ The effective buffer size then is variable depending on the format:
   stereo 16-bit | 4            | 8192
 
 Whenever the internal position is half-way through the buffer, it raises an interrupt of vector 0xFE (address 0x000003F8).
-When this interrupt is raised, the refill pending flag (bit 1) is set, and must be cleared
-in order for future refill interrupts to happen. In that case, a value of 0 must be written
-to clear the flag.
+When this interrupt is raised, the refill pending flag (bit 1) is set. The flag is cleared when the buffer wraps around to its beginning.
+The processor cannot write to this flag; it can only read from it.

--- a/docs/audio.md
+++ b/docs/audio.md
@@ -2,7 +2,7 @@
 
 The audio controller manages 8 PCM audio channels, summing them together
 to produce the final audio output. The controller has a maximum output rate
-of 48 kHz and can handle 8-bit or 16-bit PCM samples from any physical address in memory.
+of 48 kHz and can handle signed 8-bit or signed 16-bit PCM samples from any physical address in memory.
 
 Each channel has 3 volume controls: the channel volume, the left volume, and the right volume.
 The channel is scaled by the channel volume (0-127), and then by the left and right volumes (both 0-255).
@@ -31,6 +31,9 @@ Registers relating to the current status of the audio controller are located at 
   0x81  | audio controller state
 
 The range from 0x82-0xFF is unused and reserved for future expansions.
+
+The samples provided to the audio controller must be signed.
+Playing an unsigned sample will cause artifacts and distorted playback.
 
 ### 0xX0: Sample position (Read)
 Read this register to get the current position of the sample being played in the audio channel.
@@ -111,7 +114,7 @@ no samples are fetched until a non-zero rate is set.
   \>128    | undefined behaviour
 
 If bit 0 of this port is set, the channels are disabled and the controller expects
-a contiguous area of 32 kilobytes (32,768 bytes) for the audio buffer. This allows for
+a contiguous area of 32 kilobytes (32,768 bytes) relative to the sample base (specified at port 0x80) for the audio buffer. This allows for
 software-driven mixing and provides more control over the audio output.
 The format of this buffer is determined by bits 4 and 5:
   value    | description

--- a/docs/cpu.md
+++ b/docs/cpu.md
@@ -180,10 +180,7 @@ or 0x0 when no handler has been installed.
 | type      | vector   | description
 |-----------|----------|-------------------------------------------
 | interrupt | 0 - 0xF0 | free for software use
-| interrupt | 0xFB     | audio channel 3 refill
-| interrupt | 0xFC     | audio channel 2 refill
-| interrupt | 0xFD     | audio channel 1 refill
-| interrupt | 0xFE     | audio channel 0 refill
+| interrupt | 0xFE     | audio buffer low
 | interrupt | 0xFF     | display VSYNC
 | exception | 0x00     | divide by zero
 | exception | 0x01     | invalid opcode

--- a/docs/io_bus.md
+++ b/docs/io_bus.md
@@ -121,7 +121,7 @@ range from $81-$ff is also unused and reserved for future expansions.
  offset (X = 0...3) | description
 --------------------|------------------
   0xX0              | audio channel X sample start
-  0xX1              | audio channel X sample start
+  0xX1              | audio channel X sample end
   0xX2              | audio channel X loop point start
   0xX3              | audio channel X loop point end
   0xX4              | audio channel X rate
@@ -147,10 +147,10 @@ Read this register to get the current value of the channel phase accumulator.
 
 ### 0xX4: Channel rate (Write)
 Write a number here to specify the rate at which samples are fetched.
-The theoretical range is from 0 to 4294967295 (2^32 - 1), however the recommended minimum is
+The theoretical range is from 0 to 4294967295 (2^32 - 1), however the recommended maximum is
 65536, since higher rates may result in undefined behaviour.
 
-A desired rate R can be calculated according to the formula: $\frac{R}{48000}\times2^{16}$. To play a sample at a sample rate of 48kHz, calculate the rate: $\frac{48000}{48000}\times2^{16} = 65536$ and write the resulting rate to this register.
+A desired rate R can be calculated according to the formula: $\frac{R}{48000}\times2^{16}$. To play a sample at a sample rate of 48kHz, calculate the rate: $\frac{48000}{48000}\times2^{16} = 65536$ and write the resulting rate of 65536 to this register.
 
 ### 0xX5: Audio channel control (Read, Write)
 

--- a/docs/io_bus.md
+++ b/docs/io_bus.md
@@ -108,17 +108,20 @@ currently available.
 
 ## 0x80000600-0x80000680: Audio
 
-The audio controller manages 4 PCM audio channels and sums them together
+The audio controller manages 8 PCM audio channels and sums them together
 to get the final audio output. The controller has a maximum output rate
 of 48kHz and can handle 8-bit/16-bit PCM samples at any physical address in memory.
 
-All of the channel registers for the 4 channels are accessed at $00-$3f. The upper
+All of the channel registers for the 8 channels are accessed at $00-$7F. The upper
 nibble determines the channel number, while the lower number determines the register.
 
-The range between $40-$7f is unused, and any reads here will return a 0. The remaining
-range from $81-$ff is also unused and reserved for future expansions.
+The range from $81-$FF is unused and reserved for future expansions.
 
- offset (X = 0...3) | description
+Each channel has 3 volume controls: the channel volume, the left volume and the right volume.
+The channel is scaled by the channel volume (0-127), then it is scaled according to the left
+and right volumes (both 0-255).
+
+ offset (X = 0...7) | description
 --------------------|------------------
   0xX0              | audio channel X sample start
   0xX1              | audio channel X sample end
@@ -126,13 +129,14 @@ range from $81-$ff is also unused and reserved for future expansions.
   0xX3              | audio channel X loop point end
   0xX4              | audio channel X rate
   0xX5              | audio channel X control
+  0xX6              | audio channel X panning
   0x80              | audio controller sample base
 
 ### 0xX0: Sample position (Read)
-Read this register to get the current position in the sample that is playing in the audio channel.
+Read this register to get the current position of the sample that is playing in the audio channel.
 
 ### 0xX1: Sample data (Read)
-Read this register to get the current output sample of the audio channel.
+Read this register to get the current output sample of the audio channel (16-bit half).
 
 ### 0xX0, 0xX1: Sample start and end (Write)
 Write a number to these registers to specify the start and end of the sample relative to
@@ -156,11 +160,18 @@ A desired rate R can be calculated according to the formula: $\frac{R}{48000}\ti
 
  bits   | description
 --------|------------------
-  15:10 | not used
-  9     | 0=8-bit PCM, 1=16-bit PCM (write-only)
+  31:10 | not used
+  9     | 0=8-bit PCM, 1=16-bit PCM
   8     | enable
   7     | loop
   6:0   | volume (0-127)
+
+### 0xX6: Audio panning control (Read, Write)
+
+ bits   | description
+--------|------------------
+  15:8  | left volume (0-255)
+  7:0   | right volume (0-255)
 
 ## 0x80000700: Real-Time Clock (RTC) and Uptime
 

--- a/docs/io_bus.md
+++ b/docs/io_bus.md
@@ -106,20 +106,12 @@ currently available.
   6:0   | PC-compatible keyboard scancode
 
 
-## 0x80000600-0x80000680: Audio
-
-The audio controller manages 8 PCM audio channels and sums them together
-to get the final audio output. The controller has a maximum output rate
-of 48kHz and can handle 8-bit/16-bit PCM samples at any physical address in memory.
+## 0x80000600-0x80000681: Audio
 
 All of the channel registers for the 8 channels are accessed at $00-$7F. The upper
 nibble determines the channel number, while the lower number determines the register.
 
-The range from $81-$FF is unused and reserved for future expansions.
-
-Each channel has 3 volume controls: the channel volume, the left volume and the right volume.
-The channel is scaled by the channel volume (0-127), then it is scaled according to the left
-and right volumes (both 0-255).
+The range from $82-$FF is unused and reserved for future expansions.
 
  offset (X = 0...7) | description
 --------------------|------------------
@@ -131,47 +123,9 @@ and right volumes (both 0-255).
   0xX5              | audio channel X control
   0xX6              | audio channel X panning
   0x80              | audio controller sample base
+  0x81              | audio controller state
 
-### 0xX0: Sample position (Read)
-Read this register to get the current position of the sample that is playing in the audio channel.
-
-### 0xX1: Sample data (Read)
-Read this register to get the current output sample of the audio channel (16-bit half).
-
-### 0xX0, 0xX1: Sample start and end (Write)
-Write a number to these registers to specify the start and end of the sample relative to
-the controller's sample base.
-
-### 0xX2, 0xX3: Loop point start and end (Write-only)
-Write a number to these registers to specify the start and end of the sample relative to
-the controller's sample base. Reading these registers will return a 0.
-
-### 0xX4: Channel accumulator (Read)
-Read this register to get the current value of the channel phase accumulator.
-
-### 0xX4: Channel rate (Write)
-Write a number here to specify the rate at which samples are fetched.
-The theoretical range is from 0 to 4294967295 (2^32 - 1), however the recommended maximum is
-65536, since higher rates may result in undefined behaviour.
-
-A desired rate R can be calculated according to the formula: $\frac{R}{48000}\times2^{16}$. To play a sample at a sample rate of 48kHz, calculate the rate: $\frac{48000}{48000}\times2^{16} = 65536$ and write the resulting rate of 65536 to this register.
-
-### 0xX5: Audio channel control (Read, Write)
-
- bits   | description
---------|------------------
-  31:10 | not used
-  9     | 0=8-bit PCM, 1=16-bit PCM
-  8     | enable
-  7     | loop
-  6:0   | volume (0-127)
-
-### 0xX6: Audio panning control (Read, Write)
-
- bits   | description
---------|------------------
-  15:8  | left volume (0-255)
-  7:0   | right volume (0-255)
+For more details, see [audio.md](audio.md).
 
 ## 0x80000700: Real-Time Clock (RTC) and Uptime
 

--- a/src/bus.c
+++ b/src/bus.c
@@ -96,7 +96,7 @@ int bus_io_read(void *user, uint32_t *value, uint32_t port) {
 
             break;
         }
-        case 0x80000600 ... 0x80000680: { // audio port
+        case 0x80000600 ... 0x80000681: { // audio port
             size_t id = port & 0xFF;
             uint8_t channel = (id & 0x30) >> 4;
             uint8_t reg = (id & 0x0F);
@@ -106,6 +106,15 @@ int bus_io_read(void *user, uint32_t *value, uint32_t port) {
                     *value = snd.base;
                     break;
                 }
+				case 0x81: {
+                    // AUDCTL
+                    snd.buffer = value & 0x01;
+					snd.refill_pending = value & 0x02;
+					snd.buffer_mode = (value & 0x30) >> 4;
+					snd.buffer_rate = (value & 0xff00) >> 8;
+					*value = snd.buffer | (snd.refill_pending << 1) | (snd.buffer_mode << 4) | (snd.buffer_rate << 8);
+                    break;
+				}
             }
             switch (reg) {
                 case 0x0: {
@@ -266,19 +275,24 @@ int bus_io_write(void *user, uint32_t value, uint32_t port) {
             break;
         };
 
-        case 0x80000600 ... 0x80000680: { // audio port
+        case 0x80000600 ... 0x80000681: { // audio port
             size_t id = port & 0xFF;
             uint8_t channel = (id & 0x30) >> 4;
             uint8_t reg = (id & 0x0F);
             switch (id) {
                 case 0x80: {
                     // AUDBASE
+					printf("AUDBASE: %08x\n", value);
                     snd.base = value;
                     break;
                 }
 				case 0x81: {
+                    printf("AUDCTL: %08x\n", value);
                     // AUDCTL
-                    snd.inhibit = value & 0x01;
+                    snd.buffer = value & 0x01;
+					snd.refill_pending = value & 0x02;
+					snd.buffer_mode = (value & 0x30) >> 4;
+					snd.buffer_rate = (value & 0xff00) >> 8;
                     break;
                 }
             }

--- a/src/bus.c
+++ b/src/bus.c
@@ -276,6 +276,11 @@ int bus_io_write(void *user, uint32_t value, uint32_t port) {
                     snd.base = value;
                     break;
                 }
+				case 0x81: {
+                    // AUDCTL
+                    snd.inhibit = value & 0x01;
+                    break;
+                }
             }
             switch (reg) {
                 case 0x0: {

--- a/src/bus.c
+++ b/src/bus.c
@@ -284,7 +284,6 @@ int bus_io_write(void *user, uint32_t value, uint32_t port) {
                 case 0x81: {
                     // AUDCTL
                     snd.buffer = value & 0x01;
-                    snd.refill_pending = value & 0x02;
                     snd.buffer_mode = (value & 0x30) >> 4;
                     snd.buffer_rate = (value & 0xff00) >> 8;
                     break;

--- a/src/bus.c
+++ b/src/bus.c
@@ -106,15 +106,11 @@ int bus_io_read(void *user, uint32_t *value, uint32_t port) {
                     *value = snd.base;
                     break;
                 }
-				case 0x81: {
+                case 0x81: {
                     // AUDCTL
-                    snd.buffer = value & 0x01;
-					snd.refill_pending = value & 0x02;
-					snd.buffer_mode = (value & 0x30) >> 4;
-					snd.buffer_rate = (value & 0xff00) >> 8;
-					*value = snd.buffer | (snd.refill_pending << 1) | (snd.buffer_mode << 4) | (snd.buffer_rate << 8);
+                    *value = snd.buffer | (snd.refill_pending << 1) | (snd.buffer_mode << 4) | (snd.buffer_rate << 8);
                     break;
-				}
+                }
             }
             switch (reg) {
                 case 0x0: {
@@ -282,17 +278,15 @@ int bus_io_write(void *user, uint32_t value, uint32_t port) {
             switch (id) {
                 case 0x80: {
                     // AUDBASE
-					printf("AUDBASE: %08x\n", value);
                     snd.base = value;
                     break;
                 }
-				case 0x81: {
-                    printf("AUDCTL: %08x\n", value);
+                case 0x81: {
                     // AUDCTL
                     snd.buffer = value & 0x01;
-					snd.refill_pending = value & 0x02;
-					snd.buffer_mode = (value & 0x30) >> 4;
-					snd.buffer_rate = (value & 0xff00) >> 8;
+                    snd.refill_pending = value & 0x02;
+                    snd.buffer_mode = (value & 0x30) >> 4;
+                    snd.buffer_rate = (value & 0xff00) >> 8;
                     break;
                 }
             }

--- a/src/bus.c
+++ b/src/bus.c
@@ -106,10 +106,6 @@ int bus_io_read(void *user, uint32_t *value, uint32_t port) {
                     *value = snd.base;
                     break;
                 }
-                default: {
-                    *value = 0;
-                    break;
-                }
             }
             switch (reg) {
                 case 0x0: {
@@ -129,11 +125,12 @@ int bus_io_read(void *user, uint32_t *value, uint32_t port) {
                 }
                 case 0x5: {
                     // AUDxCONTROL
-                    *value = snd.channel[channel].volume | (snd.channel[channel].loop << 7) | (snd.channel[channel].enable << 8);
+                    *value = snd.channel[channel].volume | (snd.channel[channel].loop << 7) | (snd.channel[channel].enable << 8) | (snd.channel[channel].bits16 << 9);
                     break;
                 }
-                default: {
-                    *value = 0;
+                case 0x6: {
+                    // AUDxPAN
+                    *value = snd.channel[channel].right_volume | (snd.channel[channel].left_volume << 8);
                     break;
                 }
             }
@@ -312,6 +309,12 @@ int bus_io_write(void *user, uint32_t value, uint32_t port) {
                     snd.channel[channel].loop = value & 0x00000080;
                     snd.channel[channel].enable = value & 0x00000100;
                     snd.channel[channel].bits16 = value & 0x00000200;
+                    break;
+                }
+                case 0x6: {
+                    // AUDxPAN
+                    snd.channel[channel].right_volume = value & 0x000000FF;
+                    snd.channel[channel].left_volume = (value & 0x0000FF00) >> 8;
                     break;
                 }
             }

--- a/src/main.c
+++ b/src/main.c
@@ -21,6 +21,7 @@
 #include "mouse.h"
 #include "screen.h"
 #include "serial.h"
+#include "sound.h"
 
 #include "../fox32rom.h"
 
@@ -32,6 +33,7 @@ fox32_vm_t vm;
 
 extern bool bus_requests_exit;
 extern disk_controller_t disk_controller;
+extern sound_t snd;
 
 uint32_t tick_start;
 uint32_t tick_end;
@@ -118,7 +120,7 @@ int main(int argc, char *argv[]) {
 #endif
 
     if (!vm.headless) {
-        if (SDL_Init(SDL_INIT_VIDEO) != 0) {
+        if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO) != 0) {
             fprintf(stderr, "unable to initialize SDL: %s", SDL_GetError());
             return 1;
         }
@@ -136,6 +138,7 @@ int main(int argc, char *argv[]) {
             mouse_moved,
             drop_file
         );
+        sound_init();
 
         ScreenInit();
         ScreenDraw();

--- a/src/sound.c
+++ b/src/sound.c
@@ -53,6 +53,9 @@ void sound_step() {
             }
         }
         snd.buffer_pos = snd.buffer_pos % FOX32_AUDIO_BUFFER_SIZE;
+        if (snd.buffer_pos < (FOX32_AUDIO_BUFFER_SIZE/2)) {
+            snd.refill_pending = false;
+        }
         if (snd.buffer_pos >= (FOX32_AUDIO_BUFFER_SIZE/2)) {
             if (!snd.refill_pending) {
                 fox32_raise(&vm, FOX32_AUDIO_BUFFER_IRQ);

--- a/src/sound.c
+++ b/src/sound.c
@@ -1,0 +1,82 @@
+#include <SDL2/SDL.h>
+#include <getopt.h>
+#include <math.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "cpu.h"
+#include "sound.h"
+
+sound_t snd;
+extern fox32_vm_t vm;
+
+void sound_step() {
+    snd.out = 0;
+    for (int i=0; i<4; i++) {
+        if (snd.channel[i].enable && !snd.channel[i].last_enable) {
+            snd.channel[i].position = snd.channel[i].start;
+        } else if (!snd.channel[i].enable && snd.channel[i].last_enable) {
+            snd.channel[i].position = snd.channel[i].end;
+            snd.channel[i].data = 0;
+        }
+        
+        if (snd.channel[i].enable) {
+            /* phase accumulator for handling sample rates that are not multiple of 48kHz */
+            snd.channel[i].accumulator += snd.channel[i].frequency;
+            if (snd.channel[i].accumulator >= (1 << 16)) {
+                snd.channel[i].accumulator -= (1 << 16);
+                if (snd.channel[i].position < snd.channel[i].end) {
+                    uint32_t abs = snd.base + snd.channel[i].position;
+                    if (snd.channel[i].bits16) {
+                        /* 16-bit PCM mode */
+                        snd.channel[i].data = (vm.memory_ram[abs]) | (vm.memory_ram[abs+1] << 8);
+                        snd.channel[i].position += 2;
+                    } else {
+                        /* 8-bit PCM mode */
+                        snd.channel[i].data = (int16_t)(vm.memory_ram[abs] << 8);
+                        snd.channel[i].position++;
+                    }
+                    /* loop mode */
+                    if (snd.channel[i].loop && snd.channel[i].position >= snd.channel[i].loop_end) {
+                        snd.channel[i].position = snd.channel[i].loop_start;
+                    }
+                } else {
+                    /* silence the output to ensure we do not output a dangling sample */
+                    snd.channel[i].enable = false;
+                    snd.channel[i].last_enable = false;
+                    snd.channel[i].data = 0;
+                }
+            }
+        } else {
+            /* output nothing */
+            snd.channel[i].data = 0;
+        }
+        snd.channel[i].last_enable = snd.channel[i].enable;
+        snd.out += snd.channel[i].data * ((float)(snd.channel[i].volume & 0x7f) / 127.0f);
+    }
+}
+
+void sound_callback(void* userdata, uint8_t* stream, int len) {
+    (void)userdata; /* all warnings on, userdata is unused, suppress that warning */
+    int16_t* buffer = (int16_t*)stream;
+    for (int i=0; i<len/2; i++) {
+        sound_step();
+        buffer[i] = snd.out >> 1;
+    }
+}
+
+void sound_init() {
+    memset(&snd, 0, sizeof(snd));
+    SDL_AudioSpec spec = {0};
+    spec.freq = 48000;
+    spec.format = AUDIO_S16SYS;
+    spec.channels = 1;
+    spec.samples = 4096;
+    spec.callback = sound_callback;
+    SDL_OpenAudio(&spec, 0);
+    SDL_PauseAudio(0); 
+}

--- a/src/sound.h
+++ b/src/sound.h
@@ -1,0 +1,61 @@
+#pragma once
+
+typedef struct {
+	uint32_t start;
+	uint32_t end;
+	uint32_t loop_start;
+	uint32_t loop_end;
+	bool loop;
+	bool enable;
+	bool last_enable;
+	
+	uint8_t volume;
+	
+	uint32_t accumulator;
+	uint32_t frequency;
+	
+	bool bits16;
+	
+	uint32_t position;
+	int16_t data;
+} sound_channel_t;
+
+typedef struct {
+	sound_channel_t channel[4];
+	uint32_t base;
+	int32_t out;
+} sound_t;
+
+void sound_init();
+
+/*
+audio ports start at 0x80000600
+
+writing:
+0x800006x0 - AUDxSTART (32-bit)
+0x800006x1 - AUDxEND (32-bit)
+0x800006x2 - AUDxLOOPSTART (32-bit)
+0x800006x3 - AUDxLOOPEND (32-bit)
+0x800006x4 - AUDxRATE (32-bit)
+0x800006x5 - AUDxCONTROL
+	bit 15:9 - 0
+	bit 9 - 8/16-bit PCM select (0 = 8-bit, 1 = 16-bit)
+	bit 8 - enable (1=sound on, 0=sound off)
+	bit 7 - loop
+	bit 6:0 - volume
+0x80000680 - AUDBASE
+
+reading:
+0x800006x0 - AUDxPOS (32-bit)
+0x800006x1 - AUDxDAT (32-bit)
+0x800006x2 - null 
+0x800006x3 - null
+0x800006x4 - AUDxRATE (32-bit)
+0x800006x5 - AUDxCONTROL
+	bit 15:9 - 0
+	bit 9 - 8/16-bit PCM select (0 = 8-bit, 1 = 16-bit)
+	bit 8 - enable (1=sound on, 0=sound off)
+	bit 7 - loop
+	bit 6:0 - volume
+0x80000680 - AUDBASE
+*/

--- a/src/sound.h
+++ b/src/sound.h
@@ -1,29 +1,34 @@
 #pragma once
 
+#define FOX32_AUDIO_CHANNELS 8
+
 typedef struct {
-	uint32_t start;
-	uint32_t end;
-	uint32_t loop_start;
-	uint32_t loop_end;
-	bool loop;
-	bool enable;
-	bool last_enable;
-	
-	uint8_t volume;
-	
-	uint32_t accumulator;
-	uint32_t frequency;
-	
-	bool bits16;
-	
-	uint32_t position;
-	int16_t data;
+    uint32_t start;
+    uint32_t end;
+    uint32_t loop_start;
+    uint32_t loop_end;
+    bool loop;
+    bool enable;
+    bool last_enable;
+    
+    uint8_t volume;
+    uint8_t left_volume;
+    uint8_t right_volume;
+    
+    uint32_t accumulator;
+    uint32_t frequency;
+    
+    bool bits16;
+    
+    uint32_t position;
+    int16_t data;
 } sound_channel_t;
 
 typedef struct {
-	sound_channel_t channel[4];
-	uint32_t base;
-	int32_t out;
+    sound_channel_t channel[FOX32_AUDIO_CHANNELS];
+    uint32_t base;
+    int32_t out_left;
+    int32_t out_right;
 } sound_t;
 
 void sound_init();
@@ -38,11 +43,14 @@ writing:
 0x800006x3 - AUDxLOOPEND (32-bit)
 0x800006x4 - AUDxRATE (32-bit)
 0x800006x5 - AUDxCONTROL
-	bit 15:9 - 0
-	bit 9 - 8/16-bit PCM select (0 = 8-bit, 1 = 16-bit)
-	bit 8 - enable (1=sound on, 0=sound off)
-	bit 7 - loop
-	bit 6:0 - volume
+    bit 15:10 - 0
+    bit 9 - 8/16-bit PCM select (0 = 8-bit, 1 = 16-bit)
+    bit 8 - enable (1=sound on, 0=sound off)
+    bit 7 - loop
+    bit 6:0 - volume
+0x800006x6 - AUDxPAN
+    bit 15:8 - left volume 0-255
+    bit 7:0 - right volume 0-255
 0x80000680 - AUDBASE
 
 reading:
@@ -52,10 +60,10 @@ reading:
 0x800006x3 - null
 0x800006x4 - AUDxRATE (32-bit)
 0x800006x5 - AUDxCONTROL
-	bit 15:10 - 0
-	bit 9 - 8/16-bit PCM select (0 = 8-bit, 1 = 16-bit)
-	bit 8 - enable (1=sound on, 0=sound off)
-	bit 7 - loop
-	bit 6:0 - volume
+    bit 15:10 - 0
+    bit 9 - 8/16-bit PCM select (0 = 8-bit, 1 = 16-bit)
+    bit 8 - enable (1=sound on, 0=sound off)
+    bit 7 - loop
+    bit 6:0 - volume
 0x80000680 - AUDBASE
 */

--- a/src/sound.h
+++ b/src/sound.h
@@ -52,7 +52,7 @@ reading:
 0x800006x3 - null
 0x800006x4 - AUDxRATE (32-bit)
 0x800006x5 - AUDxCONTROL
-	bit 15:9 - 0
+	bit 15:10 - 0
 	bit 9 - 8/16-bit PCM select (0 = 8-bit, 1 = 16-bit)
 	bit 8 - enable (1=sound on, 0=sound off)
 	bit 7 - loop


### PR DESCRIPTION
currently, the fox32 emulator does not have support for audio (and i was quite... naggy). the older Rust-based emulator supported audio, but the audio system as used in that emulator was... not exactly adequate (an audio buffer of 32768 bytes at a fixed memory address that was fetched every 500ms and ran at a rate of 22.5kHz)

at long last, this pull request implements an audio controller that runs at 48kHz, 8 channels of signed 8-bit/16-bit PCM (with an optional mode to use audio buffering for software-driven audio).

task list:
- [x] basic audio support in the emulator
- [x] implement channels
- [x] implement buffered mode
- [x] documentation(-ish)
the documentation still needs to be proofread thoroughly and errors corrected. it should however be usable for most purposes. see [audio.md](https://github.com/host12prog/fox32/blob/main/docs/audio.md)
- [x] testing(-ish)

the audio controller right now has not currently undergone very rigorous testing, so there are still some unknowns:
- ~~does the audio controller clip in order to prevent an overflow in the event all channels are playing loud samples?~~ (answer: yes, it does)
- ~~can the audio controller mixer handle 8 channels of variable bit-depth without overflowing?~~ (answer: yes)
- ~~what happens if the channel rate is set above 65536?~~ (answer: it maxes out at 48kHz and cannot go any higher)
- is the audio buffering mode adequate for software-driven mixing? (answer: time will tell because i do not have the capability to test this)
- etc...

of course, i cannot test this very thoroughly by myself, so if you want to, you can stress-test the audio controller until most bugs and kinks are ironed out :)

by the way: i know this is the fox32 repo and not the fox32asm repo, but can we get a way to calculate the size of some data between 2 labels? it would be very useful for calculating sample size