### PR TITLE
Fix serial console on Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ ifeq ($(TARGET),mingw)
 CC = x86_64-w64-mingw32-gcc
 SDL2_CONFIG = /usr/local/x86_64-w64-mingw32/bin/sdl2-config
 CFLAGS += -g -Ofast -std=c99 -Wall -Wextra -DWINDOWS -I/usr/local/x86_64-w64-mingw32/include -Dmain=SDL_main
-LDFLAGS += -lmingw32 -lSDL2main -lSDL2 -L/usr/local/x86_64-w64-mingw32/lib -lmingw32 -lSDL2main -lSDL2 -mwindows
+LDFLAGS += -lmingw32 -lSDL2main -lSDL2 -L/usr/local/x86_64-w64-mingw32/lib -lmingw32 -lSDL2main -lSDL2
 TARGET_FILE_EXTENSION = .exe
 else
 ifeq ($(TARGET),wasm)

--- a/src/bus.c
+++ b/src/bus.c
@@ -32,12 +32,10 @@ extern sound_t snd;
 int bus_io_read(void *user, uint32_t *value, uint32_t port) {
     (void) user;
     switch (port) {
-#ifndef WINDOWS
         case 0x00000000: { // serial port
             *value = serial_get();
             break;
         };
-#endif
         case 0x80000000 ... 0x8000031F: { // overlay port
             uint8_t overlay_number = port & 0x000000FF;
             uint8_t setting = (port & 0x0000FF00) >> 8;

--- a/src/main.c
+++ b/src/main.c
@@ -144,9 +144,7 @@ int main(int argc, char *argv[]) {
         ScreenDraw();
     }
 
-#ifndef WINDOWS
     serial_init();
-#endif
 
     tick_start = SDL_GetTicks();
     tick_end = SDL_GetTicks();

--- a/src/serial.c
+++ b/src/serial.c
@@ -1,13 +1,15 @@
 #include <stdio.h>
-#ifndef WINDOWS
-#include <sys/select.h>
-#include <unistd.h>
-#include <termios.h>
 #include <stdbool.h>
 #include <stdlib.h>
 
-static struct termios saved_tios;
 static bool is_terminal = false;
+
+#if !defined(WINDOWS)
+#include <sys/select.h>
+#include <unistd.h>
+#include <termios.h>
+
+static struct termios saved_tios;
 
 static void exit_handler(void) {
     if (is_terminal)
@@ -48,6 +50,54 @@ int serial_get(void) {
             return c;
     }
 
+    return 0;
+}
+
+#elif defined(WINDOWS)
+#include <Windows.h>
+
+static DWORD old_mode;
+static HANDLE hStdin;
+
+static void exit_handler(void) {
+    if (is_terminal)
+        SetConsoleMode(hStdin, old_mode);
+}
+
+void serial_init(void) {
+    hStdin = GetStdHandle(STD_INPUT_HANDLE);
+    if (GetConsoleMode(hStdin, &old_mode)) {
+        is_terminal = true;
+        atexit(exit_handler);
+        SetConsoleMode(hStdin, old_mode & ~(ENABLE_LINE_INPUT | ENABLE_ECHO_INPUT));
+    }
+}
+
+int serial_get(void) {
+    if (!is_terminal) {
+        return 0;
+    }
+    
+    DWORD events;
+    INPUT_RECORD buffer;
+    DWORD eventsRead;
+    if (!GetNumberOfConsoleInputEvents(hStdin, &events) || events == 0) {
+        return 0;
+    }
+    if (!ReadConsoleInput(hStdin, &buffer, 1, &eventsRead) || eventsRead == 0) {
+        return 0;
+    }
+    if (buffer.EventType == KEY_EVENT && buffer.Event.KeyEvent.bKeyDown) {
+        unsigned char c = buffer.Event.KeyEvent.uChar.AsciiChar;
+        if (c != 0) {
+            if (c == '\r') {
+                // man why does Windows have to return a Carriage Return here
+                // sh.fxf (and presumably other programs) only checks for a Line Feed
+                return '\n';
+            }
+            return c;
+        }
+    }
     return 0;
 }
 


### PR DESCRIPTION
fixes serial console on Windows
it wasn't broken on Windows, the functions to do it were stubbed out and the build process meant it'd build without a terminal attached to it (because it was built with the `-mwindows` flag)

now unfortunately there are some kinks (see Appendix A) in it but it is functional enough to the point it can be reliably used (and i don't have the capacity to try to figure out why it's janky like that) :)

- Appendix A:
  <img width="180" height="288" alt="image" src="https://github.com/user-attachments/assets/2240a3e2-87e4-4135-a905-4fe74458826b" />