### PR TITLE
reset audio channel position on every enable bit write

### DIFF
--- a/src/bus.c
+++ b/src/bus.c
@@ -319,6 +319,9 @@ int bus_io_write(void *user, uint32_t value, uint32_t port) {
                     snd.channel[channel].loop = value & 0x00000080;
                     snd.channel[channel].enable = value & 0x00000100;
                     snd.channel[channel].bits16 = value & 0x00000200;
+				    if (snd.channel[channel].enable) {
+				        snd.channel[channel].position = snd.channel[channel].start;
+				    }
                     break;
                 }
                 case 0x6: {


### PR DESCRIPTION
it's been a while since i last worked on audio. this is a very simple fix that just modifies the behavior such that if you write to the enable bit with a 1, then it will always reset the position back to the start (documentation changes pending)