### PR TITLE
audio system improvements

### DIFF
--- a/docs/audio.md
+++ b/docs/audio.md
@@ -108,6 +108,19 @@ write to it to set the base.
   1     | buffer 0 refill pending flag
   0     | buffer mode (0=use channels, 1=use buffer)
 
+During a refill interrupt, a 0 should be written to the corresponding buffer refill pending flag. This can be done with
+the following:
+```avrasm
+; acknowledge interrupt for buffer 0
+in r0, 0x80000681
+bcl r0, 1
+out 0x80000681, r0
+; acknowledge interrupt for buffer 1
+in r0, 0x80000681
+bcl r0, 2
+out 0x80000681, r0
+```
+
 Bits 15 to 8 specify the rate at which samples are fetched from the buffer. The formula for calculating
 the rate for a given sample rate (F) is $\frac{F}{48000}\times2^{7}$. A value of 0 halts the internal counter and
 no samples are fetched until a non-zero rate is set.

--- a/docs/audio.md
+++ b/docs/audio.md
@@ -29,8 +29,11 @@ Registers relating to the current status of the audio controller are located at 
 --------|------------------
   0x80  | audio controller sample base
   0x81  | audio controller state
+  0x82  | audio controller buffer 0 start location
+  0x83  | audio controller buffer 1 start location
+  0x84  | audio controller buffer length
 
-The range from 0x82-0xFF is unused and reserved for future expansions.
+The range from 0x85-0xFF is unused and reserved for future expansions.
 
 The samples provided to the audio controller must be signed.
 Playing an unsigned sample will cause artifacts and distorted playback.
@@ -81,6 +84,8 @@ and write the resulting rate of 65536 to this register.
   6:0   | volume (0-127)
 
 When using 16-bit PCM, the audio controller fetches 16-bit data as a little-endian word.
+The enable bit is write-strobed, therefore if you write a 1 to it, it will restart the
+channel from its start address, and a 0 will silence the output.
 
 ### 0xX6: Audio panning control (Read, Write)
 
@@ -99,7 +104,8 @@ write to it to set the base.
 --------|------------------
   15:8  | buffer rate
   5:4   | buffer format
-  1     | refill pending flag (read-only)
+  2     | buffer 1 refill pending flag
+  1     | buffer 0 refill pending flag
   0     | buffer mode (0=use channels, 1=use buffer)
 
 Bits 15 to 8 specify the rate at which samples are fetched from the buffer. The formula for calculating
@@ -113,9 +119,8 @@ no samples are fetched until a non-zero rate is set.
   0        | stops playback
   \>128    | undefined behaviour
 
-If bit 0 of this port is set, the channels are disabled and the controller expects
-a contiguous area of 32 kilobytes (32,768 bytes) relative to the sample base (specified at port 0x80) for the audio buffer. This allows for
-software-driven mixing and provides more control over the audio output.
+If bit 0 of this port is set, the channels are disabled and the controller uses 2 buffers for audio output. This allows for
+software-driven mixing and provides more control over the audio output. This mode is explained in the next section.
 The format of this buffer is determined by bits 4 and 5:
   value    | description
 -----------|--------------------
@@ -124,20 +129,26 @@ The format of this buffer is determined by bits 4 and 5:
   0b10 (2) | stereo 8-bit
   0b11 (3) | stereo 16-bit
 
-Stereo samples are fetched as frames containing left and right samples. For example, if the buffer is using stereo 8-bit PCM,
+### 0x82: Audio controller buffer 0 start address (Read, Write)
+Read from this register to get the current base address from which buffer 0 is located and
+write to it to set the address of buffer 0.
+
+### 0x83: Audio controller buffer 1 start address (Read, Write)
+Read from this register to get the current base address from which buffer 1 is located and
+write to it to set the address of buffer 1.
+
+### 0x84: Audio controller buffer length (Read, Write)
+Read from this register to get the size of the audio buffer (or to be more precise, the half-size of the audio buffer).
+Write to this register to set the size of the audio buffer. This register sets the length of both buffer 0 and 1.
+
+## Buffer mode
+When buffer mode is enabled, the audio controller disables usage of the 8 sample channels and uses 2 buffers (Buffer 0 and Buffer 1)
+to output samples. When the controller starts reading samples, it will read Buffer 0 first. When it has reached the end of Buffer 0,
+it will interrupt to the CPU to refill Buffer 0 (vector 0xFD), while it starts reading Buffer 1. When it reaches the end of Buffer 1, 
+it will also interrupt the CPU to refill Buffer 1 (vector 0xFE), and restarts reading from Buffer 0. The start address for Buffer 0 is
+determined by port 0x82, and 0x83 for Buffer 1. The length of these buffers is set by port 0x84.
+
+Stereo samples are fetched as frames containing left and right samples. For example, if the buffer is set to stereo 8-bit PCM,
 it fetches the left sample first (1 byte), then the right sample last (1 byte), advancing the internal position by 2 bytes.
 For stereo 16-bit PCM, it fetches the left sample word first (2 bytes) and the right sample word last (2 bytes),
 advancing the internal position by 4 bytes.
-
-The audio controller always uses a 32768 byte buffer, regardless of the format.
-Consequently, the effective buffer size is variable depending on the format:
-  format        | size (bytes) | buffer size (samples)
-----------------|--------------|---------------------------
-  mono 8-bit    | 1            | 32768
-  mono 16-bit   | 2            | 16384
-  stereo 8-bit  | 2            | 16384
-  stereo 16-bit | 4            | 8192
-
-Whenever the internal position is half-way through the buffer, it raises an interrupt of vector 0xFE (address 0x000003F8).
-When this interrupt is raised, the refill pending flag (bit 1) is set. The flag is cleared when the buffer wraps around to its beginning.
-The processor cannot write to this flag; it can only read from it.

--- a/docs/cpu.md
+++ b/docs/cpu.md
@@ -180,7 +180,8 @@ or 0x0 when no handler has been installed.
 | type      | vector   | description
 |-----------|----------|-------------------------------------------
 | interrupt | 0 - 0xF0 | free for software use
-| interrupt | 0xFE     | audio buffer low
+| interrupt | 0xFD     | audio buffer 0 refill
+| interrupt | 0xFE     | audio buffer 1 refill
 | interrupt | 0xFF     | display VSYNC
 | exception | 0x00     | divide by zero
 | exception | 0x01     | invalid opcode

--- a/docs/io_bus.md
+++ b/docs/io_bus.md
@@ -124,6 +124,9 @@ The range from $82-$FF is unused and reserved for future expansions.
   0xX6              | audio channel X panning
   0x80              | audio controller sample base
   0x81              | audio controller state
+  0x82              | audio controller buffer 0 start address
+  0x83              | audio controller buffer 1 start address
+  0x84              | audio controller buffer length
 
 For more details, see [audio.md](audio.md).
 

--- a/src/bus.c
+++ b/src/bus.c
@@ -94,47 +94,69 @@ int bus_io_read(void *user, uint32_t *value, uint32_t port) {
 
             break;
         }
-        case 0x80000600 ... 0x80000681: { // audio port
+        case 0x80000600 ... 0x80000684: { // audio port
             size_t id = port & 0xFF;
             uint8_t channel = (id & 0x30) >> 4;
             uint8_t reg = (id & 0x0F);
-            switch (id) {
-                case 0x80: {
-                    // AUDBASE
-                    *value = snd.base;
-                    break;
+            if (id >= 0x80) {
+                switch (id) {
+                    case 0x80: {
+                        // AUDBASE
+                        *value = snd.base;
+                        break;
+                    }
+                    case 0x81: {
+                        // AUDCTL
+                        *value = (snd.buffer ? 1 : 0)
+                                | (snd.buf0_refill_pending ? (1 << 1) : 0) 
+                                | (snd.buf1_refill_pending ? (1 << 2) : 0) 
+                                | ((snd.buffer_mode & 3) << 4) 
+                                | (snd.buffer_rate << 8);
+                        break;
+                    }
+                    case 0x82: {
+                        // AUDBASE_BUF0
+                        *value = snd.buf0_base;
+                        break;
+                    }
+                    case 0x83: {
+                        // AUDBASE_BUF1
+                        *value = snd.buf1_base;
+                        break;
+                    }
+                    case 0x84: {
+                        // AUDBUF_SIZE
+                        *value = snd.buffer_size;
+                        break;
+                    }
                 }
-                case 0x81: {
-                    // AUDCTL
-                    *value = snd.buffer | (snd.refill_pending << 1) | (snd.buffer_mode << 4) | (snd.buffer_rate << 8);
-                    break;
-                }
-            }
-            switch (reg) {
-                case 0x0: {
-                    // AUDxPOS
-                    *value = snd.channel[channel].position;
-                    break;
-                }
-                case 0x1: {
-                    // AUDxDAT
-                    *value = snd.channel[channel].data;
-                    break;
-                }
-                case 0x4: {
-                    // AUDxRATE
-                    *value = snd.channel[channel].accumulator;
-                    break;
-                }
-                case 0x5: {
-                    // AUDxCONTROL
-                    *value = snd.channel[channel].volume | (snd.channel[channel].loop << 7) | (snd.channel[channel].enable << 8) | (snd.channel[channel].bits16 << 9);
-                    break;
-                }
-                case 0x6: {
-                    // AUDxPAN
-                    *value = snd.channel[channel].right_volume | (snd.channel[channel].left_volume << 8);
-                    break;
+            } else {
+                switch (reg) {
+                    case 0x0: {
+                        // AUDxPOS
+                        *value = snd.channel[channel].position;
+                        break;
+                    }
+                    case 0x1: {
+                        // AUDxDAT
+                        *value = snd.channel[channel].data;
+                        break;
+                    }
+                    case 0x4: {
+                        // AUDxRATE
+                        *value = snd.channel[channel].accumulator;
+                        break;
+                    }
+                    case 0x5: {
+                        // AUDxCONTROL
+                        *value = snd.channel[channel].volume | (snd.channel[channel].loop << 7) | (snd.channel[channel].enable << 8) | (snd.channel[channel].bits16 << 9);
+                        break;
+                    }
+                    case 0x6: {
+                        // AUDxPAN
+                        *value = snd.channel[channel].right_volume | (snd.channel[channel].left_volume << 8);
+                        break;
+                    }
                 }
             }
             break;
@@ -269,66 +291,86 @@ int bus_io_write(void *user, uint32_t value, uint32_t port) {
             break;
         };
 
-        case 0x80000600 ... 0x80000681: { // audio port
+        case 0x80000600 ... 0x80000684: { // audio port
             size_t id = port & 0xFF;
             uint8_t channel = (id & 0x30) >> 4;
             uint8_t reg = (id & 0x0F);
-            switch (id) {
-                case 0x80: {
-                    // AUDBASE
-                    snd.base = value;
-                    break;
+            if (id >= 0x80) {
+                switch (id) {
+                    case 0x80: {
+                        // AUDBASE
+                        snd.base = value;
+                        break;
+                    }
+                    case 0x81: {
+                        // AUDCTL
+                        snd.buffer = value & 0x01;
+                        if ((value & (1 << 1)) == 0) snd.buf0_refill_pending = false;
+                        if ((value & (1 << 2)) == 0) snd.buf1_refill_pending = false;
+                        snd.buffer_mode = (value & 0x30) >> 4;
+                        snd.buffer_rate = (value & 0xff00) >> 8;
+                        break;
+                    }
+                    case 0x82: {
+                        // AUDBASE_BUF0
+                        snd.buf0_base = value;
+                        break;
+                    }
+                    case 0x83: {
+                        // AUDBASE_BUF1
+                        snd.buf1_base = value;
+                        break;
+                    }
+                    case 0x84: {
+                        // AUDBUF_SIZE
+                        snd.buffer_size = value;
+                        break;
+                    }
                 }
-                case 0x81: {
-                    // AUDCTL
-                    snd.buffer = value & 0x01;
-                    snd.buffer_mode = (value & 0x30) >> 4;
-                    snd.buffer_rate = (value & 0xff00) >> 8;
-                    break;
-                }
-            }
-            switch (reg) {
-                case 0x0: {
-                    // AUDxSTART
-                    snd.channel[channel].start = value;
-                    break;
-                }
-                case 0x1: {
-                    // AUDxEND
-                    snd.channel[channel].end = value;
-                    break;
-                }
-                case 0x2: {
-                    // AUDxLOOPSTART
-                    snd.channel[channel].loop_start = value;
-                    break;
-                }
-                case 0x3: {
-                    // AUDxLOOPEND
-                    snd.channel[channel].loop_end = value;
-                    break;
-                }
-                case 0x4: {
-                    // AUDxRATE
-                    snd.channel[channel].frequency = value;
-                    break;
-                }
-                case 0x5: {
-                    // AUDxCONTROL
-                    snd.channel[channel].volume = value & 0x0000007F;
-                    snd.channel[channel].loop = value & 0x00000080;
-                    snd.channel[channel].enable = value & 0x00000100;
-                    snd.channel[channel].bits16 = value & 0x00000200;
-				    if (snd.channel[channel].enable) {
-				        snd.channel[channel].position = snd.channel[channel].start;
-				    }
-                    break;
-                }
-                case 0x6: {
-                    // AUDxPAN
-                    snd.channel[channel].right_volume = value & 0x000000FF;
-                    snd.channel[channel].left_volume = (value & 0x0000FF00) >> 8;
-                    break;
+            } else {
+                switch (reg) {
+                    case 0x0: {
+                        // AUDxSTART
+                        snd.channel[channel].start = value;
+                        break;
+                    }
+                    case 0x1: {
+                        // AUDxEND
+                        snd.channel[channel].end = value;
+                        break;
+                    }
+                    case 0x2: {
+                        // AUDxLOOPSTART
+                        snd.channel[channel].loop_start = value;
+                        break;
+                    }
+                    case 0x3: {
+                        // AUDxLOOPEND
+                        snd.channel[channel].loop_end = value;
+                        break;
+                    }
+                    case 0x4: {
+                        // AUDxRATE
+                        snd.channel[channel].frequency = value;
+                        break;
+                    }
+                    case 0x5: {
+                        // AUDxCONTROL
+                        snd.channel[channel].volume = value & 0x0000007F;
+                        snd.channel[channel].loop = value & 0x00000080;
+                        snd.channel[channel].enable = value & 0x00000100;
+                        snd.channel[channel].bits16 = value & 0x00000200;
+                        if (snd.channel[channel].enable) {
+                            snd.channel[channel].position = snd.channel[channel].start;
+                        }
+                        break;
+                    }
+                    case 0x6: {
+                        // AUDxPAN
+                        snd.channel[channel].right_volume = value & 0x000000FF;
+                        snd.channel[channel].left_volume = (value & 0x0000FF00) >> 8;
+                        break;
+                    }
                 }
             }
             break;

--- a/src/bus.c
+++ b/src/bus.c
@@ -96,7 +96,7 @@ int bus_io_read(void *user, uint32_t *value, uint32_t port) {
         }
         case 0x80000600 ... 0x80000684: { // audio port
             size_t id = port & 0xFF;
-            uint8_t channel = (id & 0x30) >> 4;
+            uint8_t channel = (id & 0x70) >> 4;
             uint8_t reg = (id & 0x0F);
             if (id >= 0x80) {
                 switch (id) {
@@ -293,7 +293,7 @@ int bus_io_write(void *user, uint32_t value, uint32_t port) {
 
         case 0x80000600 ... 0x80000684: { // audio port
             size_t id = port & 0xFF;
-            uint8_t channel = (id & 0x30) >> 4;
+            uint8_t channel = (id & 0x70) >> 4;
             uint8_t reg = (id & 0x0F);
             if (id >= 0x80) {
                 switch (id) {

--- a/src/main.c
+++ b/src/main.c
@@ -253,10 +253,13 @@ void main_loop(void) {
             cycles_left += extra_cycles;
 
         while (cycles_left > 0) {
+            uint32_t timeslice = (cycles_left < 2000) ? cycles_left : 2000;
             uint32_t executed = 0;
 
-            error = fox32_resume(&vm, cycles_left, &executed);
+            //error = fox32_resume(&vm, cycles_left, &executed);
+            error = fox32_resume(&vm, timeslice, &executed);
             frame_cycles += executed;
+            sound_sync(executed);
             if (error != FOX32_ERR_OK) {
                 if (vm.debug) puts(fox32_strerr(error));
                 error = fox32_recover(&vm, error);
@@ -276,7 +279,7 @@ void main_loop(void) {
     }
 
     done = ScreenProcessEvents();
-    sound_sync(frame_cycles);
+    //sound_sync(frame_cycles);
 
     ticks++;
 }

--- a/src/sound.c
+++ b/src/sound.c
@@ -24,48 +24,68 @@ void sound_step() {
         uint8_t old_phase = snd.buffer_phase;
         snd.buffer_phase += snd.buffer_rate;
         if ((old_phase & 0x80) != (snd.buffer_phase & 0x80)) {
-            uint32_t abs = snd.base + snd.buffer_pos;
+            uint32_t curr_base = (snd.active_buffer == 0) ? snd.buf0_base : snd.buf1_base;
+            uint32_t abs = curr_base + snd.buffer_pos;
             switch (snd.buffer_mode & 3) {
                 case 0: {
                     /* mono 8-bit */
-                    snd.out_left = (int16_t)vm.memory_ram[abs] << 8;
+                    snd.out_left = (int16_t)(int8_t)vm.memory_ram[abs] << 8;
                     snd.out_right = snd.out_left;
                     snd.buffer_pos += 1;
                     break;
                 }
                 case 1: {
                     /* mono 16-bit */
-                    snd.out_left = vm.memory_ram[abs] | (vm.memory_ram[abs+1] << 8);
+                    snd.out_left = (int16_t)(vm.memory_ram[abs] | (vm.memory_ram[abs+1] << 8));
                     snd.out_right = snd.out_left;
                     snd.buffer_pos += 2;
                     break;
                 }
                 case 2: {
                     /* stereo 8-bit */
-                    snd.out_left = (int16_t)vm.memory_ram[abs] << 8;
-                    snd.out_right = (int16_t)vm.memory_ram[abs+1] << 8;
+                    snd.out_left = (int16_t)(int8_t)vm.memory_ram[abs] << 8;
+                    snd.out_right = (int16_t)(int8_t)vm.memory_ram[abs+1] << 8;
                     snd.buffer_pos += 2;
                     break;
                 }
                 case 3: {
                     /* stereo 16-bit */
-                    snd.out_left = vm.memory_ram[abs] | (vm.memory_ram[abs+1] << 8);
-                    snd.out_right = vm.memory_ram[abs+2] | (vm.memory_ram[abs+3] << 8);
+                    snd.out_left = (int16_t)(vm.memory_ram[abs] | (vm.memory_ram[abs+1] << 8));
+                    snd.out_right = (int16_t)(vm.memory_ram[abs+2] | (vm.memory_ram[abs+3] << 8));
                     snd.buffer_pos += 4;
                     break;
                 }
             }
         }
-        snd.buffer_pos = snd.buffer_pos % FOX32_AUDIO_BUFFER_SIZE;
-        if (snd.buffer_pos < (FOX32_AUDIO_BUFFER_SIZE/2)) {
-            snd.refill_pending = false;
-        }
-        if (snd.buffer_pos >= (FOX32_AUDIO_BUFFER_SIZE/2)) {
-            if (!snd.refill_pending) {
-                fox32_raise(&vm, FOX32_AUDIO_BUFFER_IRQ);
-                snd.refill_pending = true;
+        if (snd.buffer_pos >= snd.buffer_size) {
+            snd.buffer_pos = 0;
+            if (snd.active_buffer == 0) {
+                snd.active_buffer = 1;
+                if (!snd.buf0_refill_pending) {
+                    snd.buf0_refill_pending = true;
+                    fox32_raise(&vm, FOX32_AUDIO_BUF0_IRQ);
+                }
+            } else {
+                snd.active_buffer = 0;
+                if (!snd.buf1_refill_pending) {
+                    snd.buf1_refill_pending = true;
+                    fox32_raise(&vm, FOX32_AUDIO_BUF1_IRQ);
+                }
             }
         }
+        
+        int32_t left = snd.out_left >> 1;
+        int32_t right = snd.out_right >> 1;
+        /* clamp the audio so we don't overflow */
+        if (left > 32767) left = 32767;
+        if (left < -32768) left = -32768;
+            
+        if (right > 32767) right = 32767;
+        if (right < -32768) right = -32768;
+
+        ring_buffer[write_pos++] = (int16_t)left;
+        ring_buffer[write_pos++] = (int16_t)right;
+        write_pos %= 48000;
         return;
     }
     
@@ -89,7 +109,7 @@ void sound_step() {
                     uint32_t abs = snd.base + snd.channel[i].position;
                     if (snd.channel[i].bits16) {
                         /* 16-bit PCM mode */
-                        snd.channel[i].data = (vm.memory_ram[abs]) | (vm.memory_ram[abs+1] << 8);
+                        snd.channel[i].data = (int16_t)(vm.memory_ram[abs]) | (vm.memory_ram[abs+1] << 8);
                         snd.channel[i].position += 2;
                     } else {
                         /* 8-bit PCM mode */
@@ -133,14 +153,21 @@ void sound_step() {
 void sound_callback(void* userdata, uint8_t* stream, int len) {
     (void)userdata; /* all warnings on, userdata is unused, suppress that warning */
     int16_t* buffer = (int16_t*)stream;
+    static int16_t last_sample_l = 0;
+    static int16_t last_sample_r = 0;
     /* we generate samples every frame into a ring buffer
        therefore we only need the callback to read from it */
-    for (int i=0; i<(len/2); i++) {
+    for (int i=0; i<(len/2); i+=2) {
         if (read_pos != write_pos) {
-            buffer[i] = ring_buffer[read_pos];
+            last_sample_l = ring_buffer[read_pos];
             read_pos = (read_pos + 1) % 48000;
+            last_sample_r = ring_buffer[read_pos];
+            read_pos = (read_pos + 1) % 48000;
+            buffer[i] = last_sample_l;
+            buffer[i+1] = last_sample_r;
         } else {
-            buffer[i] = 0;
+            buffer[i] = last_sample_l;
+            buffer[i+1] = last_sample_r;
         }
     }
 }

--- a/src/sound.h
+++ b/src/sound.h
@@ -2,7 +2,8 @@
 
 #define FOX32_AUDIO_CHANNELS 8
 #define FOX32_AUDIO_BUFFER_SIZE 32768
-#define FOX32_AUDIO_BUFFER_IRQ 0xFE
+#define FOX32_AUDIO_BUF0_IRQ 0xFD
+#define FOX32_AUDIO_BUF1_IRQ 0xFE
 
 typedef struct {
     uint32_t start;
@@ -33,70 +34,17 @@ typedef struct {
     int32_t out_right;
     
     bool buffer;
-    bool refill_pending;
+    bool buf0_refill_pending;
+    bool buf1_refill_pending;
+    uint32_t buf0_base;
+    uint32_t buf1_base;
+    uint8_t active_buffer;
     uint8_t buffer_mode;
     uint8_t buffer_phase;
     uint8_t buffer_rate;
+    uint32_t buffer_size;
     uint32_t buffer_pos;
 } sound_t;
 
 void sound_init();
 void sound_sync(uint32_t cycles_executed);
-
-/*
-audio ports start at 0x80000600
-
-writing:
-0x800006x0 - AUDxSTART (32-bit)
-0x800006x1 - AUDxEND (32-bit)
-0x800006x2 - AUDxLOOPSTART (32-bit)
-0x800006x3 - AUDxLOOPEND (32-bit)
-0x800006x4 - AUDxRATE (32-bit)
-0x800006x5 - AUDxCONTROL
-    bit 31:10 - 0
-    bit 9 - 8/16-bit PCM select (0 = 8-bit, 1 = 16-bit)
-    bit 8 - enable (1=sound on, 0=sound off)
-    bit 7 - loop
-    bit 6:0 - volume
-0x800006x6 - AUDxPAN
-    bit 15:8 - left volume 0-255
-    bit 7:0 - right volume 0-255
-0x80000680 - AUDBASE
-0x80000681 - AUDCTL
-    bit 15:8 - buffer rate
-    bit 5:4 - buffer format
-        00: mono 8-bit
-        01: mono 16-bit
-        10: stereo 8-bit
-        11: stereo 16-bit
-    bit 1 - sound refill pending flag
-        write 0 here to acknowledge a refill IRQ
-    bit 0 - buffer mode
-when bit 0 of AUDCTL is 1, the channels are disabled, and the audio controller
-now expects an audio buffer of 32768 bytes at the address specified in AUDBASE.
-when the buffer position is half-way through the length (position >= 16384),
-an IRQ is raised and the sound refill pending flag is set. the flag must then be
-cleared in order for another IRQ to occur.
-
-reading:
-0x800006x0 - AUDxPOS (32-bit)
-0x800006x1 - AUDxDAT (32-bit)
-0x800006x2 - null 
-0x800006x3 - null
-0x800006x4 - AUDxRATE (32-bit)
-0x800006x5 - AUDxCONTROL
-    bit 31:10 - 0
-    bit 9 - 8/16-bit PCM select (0 = 8-bit, 1 = 16-bit)
-    bit 8 - enable (1=sound on, 0=sound off)
-    bit 7 - loop
-    bit 6:0 - volume
-0x80000680 - AUDBASE
-0x80000681 - AUDCTL
-    bit 31:16 - 0
-    bit 15:8 - buffer rate
-    bit 5:4 - buffer format
-    bit 1 - sound refill pending flag
-        a value of 1 here indicates that the buffer refill IRQ
-        has not yet been acknowledged
-    bit 0 - buffer mode
-*/


### PR DESCRIPTION
i love yapping about audio stuff... too bad no one understands what i'm saying but here we bloody go!!!
buffer mode now uses double-buffering - it fetches from Buffer 0 first, once it's read all of Buffer 0, it will raise an interrupt to refill Buffer 0, while it reads Buffer 1, and once that's read too, it will interrupt the CPU to refill Buffer 1, and it will start reading Buffer 0

oh yeah these interrupts do have to be mid-frame(!!) so i hope you don't mind but i've modified the emulator main loop to run for a slice of time (2000 instructions), then generate 2000 instructions worth of samples (this also syncs the audio controller state to the CPU). it might be a bit more CPU-intensive but this was the only way i could see buffering working reliably... but it worked reliably enough to write a 1-bit streaming DPCM decoder!!! :D the emulator performance as far as i can tell seems to be mostly the same so it shouldn't break compatibility or be incompatible with the specifications (33 MIPS -> 550k instructions per frame)

~~edit: oh yeah so it turns out i wanted to do some extra edits to the audio system... that's why i converted this pr to a draft...~~
edit 2: no this is about as good as i can make it i'll make more PRs later if i need to...